### PR TITLE
Add orchestration service and RAG-backed prompt rendering

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,0 +1,4 @@
+"""Database package exposing SQLAlchemy helpers."""
+
+from .database import Base, engine, get_db  # noqa: F401
+

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -53,3 +53,15 @@ class Snapshot(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     project = relationship("Project", back_populate="snapshots")
+
+
+class Run(Base):
+    """Store metadata about orchestration runs."""
+
+    __tablename__ = "runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    plan = Column(String)
+    status = Column(String, default="created")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    artifacts_path = Column(String, nullable=True)

--- a/backend/orchestration.py
+++ b/backend/orchestration.py
@@ -1,0 +1,44 @@
+"""Utilities for orchestration policies and artifact management."""
+
+from pathlib import Path
+from typing import Any
+
+
+class GuardrailPolicy:
+    """Simple guardrail checks for incoming plans or runs."""
+
+    def validate_plan(self, plan: str) -> None:
+        """Validate that a plan is safe to execute."""
+
+        if not plan:
+            raise ValueError("Plan must not be empty")
+        # Extremely small example guardrail to demonstrate policy hooks
+        if "DROP TABLE" in plan.upper():
+            raise ValueError("Plan contains disallowed content")
+
+
+class ReviewGate:
+    """Placeholder for review approval logic."""
+
+    def approve(self, run: Any) -> bool:
+        """Approve a run. In real scenarios this might contact human reviewers."""
+
+        return True
+
+
+class ArtifactStorage:
+    """Store artifacts for runs on the local filesystem."""
+
+    def __init__(self, base_dir: str = "artifacts") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def save_text(self, run_id: int, name: str, content: str) -> str:
+        """Persist a text artifact for a run and return its path."""
+
+        run_dir = self.base_dir / str(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        path = run_dir / name
+        path.write_text(content)
+        return str(path)
+

--- a/backend/orchestrator_service.py
+++ b/backend/orchestrator_service.py
@@ -1,0 +1,151 @@
+"""Standalone FastAPI service for orchestration and evaluation."""
+
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from jinja2 import Template
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.database import Base, engine, get_db
+from backend.database.models import Run
+from backend.orchestration import ArtifactStorage, GuardrailPolicy, ReviewGate
+
+
+# Initialise database
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Codex Orchestrator")
+
+# Orchestration helpers
+guardrails = GuardrailPolicy()
+review_gate = ReviewGate()
+artifact_storage = ArtifactStorage()
+
+
+# ---------------------------------------------------------------------------
+# RAG storage integration
+# ---------------------------------------------------------------------------
+
+
+class RAGStore:
+    """Minimal wrapper around either Chroma or Weaviate."""
+
+    def __init__(self) -> None:
+        backend = os.getenv("RAG_BACKEND", "chroma").lower()
+        if backend == "weaviate":
+            import weaviate
+
+            self.client = weaviate.Client(
+                url=os.getenv("WEAVIATE_URL", "http://localhost:8080")
+            )
+            self.collection = "Prompts"
+        else:
+            import chromadb
+
+            self.client = chromadb.PersistentClient(
+                path=os.getenv("CHROMA_PATH", "./chroma_store")
+            )
+            self.collection = self.client.get_or_create_collection("prompts")
+
+    def get_prompt(self, prompt_id: str) -> str:
+        if hasattr(self, "collection") and hasattr(self.collection, "get"):
+            result = self.collection.get(ids=[prompt_id])
+            if result and result.get("documents"):
+                return result["documents"][0]
+        else:  # weaviate
+            result = self.client.data_object.get_by_id(prompt_id, class_name=self.collection)
+            if result and result.get("properties") and result["properties"].get("text"):
+                return result["properties"]["text"]
+        raise KeyError(f"Prompt {prompt_id} not found")
+
+
+rag_store = RAGStore()
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class RunCreate(BaseModel):
+    plan: str
+    parameters: Optional[Dict[str, Any]] = None
+
+
+class EvalRequest(BaseModel):
+    run_id: int
+    score: float
+    notes: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoint implementations
+# ---------------------------------------------------------------------------
+
+
+@app.get("/plans")
+def list_plans() -> Dict[str, Any]:
+    """Return placeholder plans.
+
+    In a real implementation these might be generated dynamically or retrieved
+    from a planning service.
+    """
+
+    return {"plans": ["default"]}
+
+
+@app.post("/runs")
+def create_run(run: RunCreate, db: Session = Depends(get_db)) -> Dict[str, Any]:
+    """Create a new run after applying guardrails and review gates."""
+
+    try:
+        guardrails.validate_plan(run.plan)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    db_run = Run(plan=run.plan, status="created")
+    db.add(db_run)
+    db.commit()
+    db.refresh(db_run)
+
+    # Artifact storage example
+    artifact_storage.save_text(db_run.id, "input.json", run.json())
+
+    # Review gate – currently a no-op but keeps structure for future logic
+    review_gate.approve(db_run)
+
+    return {"run_id": db_run.id, "status": db_run.status}
+
+
+@app.get("/prompts/{prompt_id}/render")
+def render_prompt(prompt_id: str, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Render a prompt template retrieved from the RAG store."""
+
+    template_text = rag_store.get_prompt(prompt_id)
+    template = Template(template_text)
+    rendered = template.render(**(variables or {}))
+    return {"prompt": rendered}
+
+
+@app.post("/eval/run")
+def eval_run(req: EvalRequest, db: Session = Depends(get_db)) -> Dict[str, Any]:
+    """Record evaluation metadata for a run."""
+
+    run = db.query(Run).filter(Run.id == req.run_id).first()
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # For demonstration we store evaluation as an artifact
+    artifact_storage.save_text(run.id, "evaluation.json", req.json())
+
+    run.status = "evaluated"
+    db.add(run)
+    db.commit()
+
+    return {"run_id": run.id, "status": run.status}
+
+
+__all__ = ["app"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,11 @@ requests
 httpx
 transformers
 jsonschema
+SQLAlchemy
+psycopg2-binary
+chromadb
+weaviate-client
+jinja2
+email-validator
+passlib[bcrypt]
+python-jose[cryptography]


### PR DESCRIPTION
## Summary
- implement standalone FastAPI orchestrator with `/plans`, `/runs`, `/prompts/{id}/render` and `/eval/run`
- add guardrail and review gate policies with filesystem artifact storage
- store run metadata in Postgres and expose optional Chroma/Weaviate RAG store
- include required dependencies for database and auth support

## Testing
- `pytest` *(fails: cannot import name 'JWT_SECRET_KEY' from 'backend.security')*
