### PR TITLE
feat: add local hub and tool schema registry

### DIFF
--- a/codex-cli/src/main.rs
+++ b/codex-cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use futures_util::{SinkExt, StreamExt};
 use reqwest::Client;
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
@@ -33,6 +33,8 @@ enum Commands {
     Eval { project: String },
     /// Deploy the project
     Deploy { project: String },
+    /// List available MCP tools
+    Tools,
 }
 
 #[tokio::main]
@@ -89,6 +91,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .send()
                 .await?;
             println!("{}", res.text().await?);
+        }
+        Commands::Tools => {
+            let schemas: Value = serde_json::from_str(include_str!("../../shared/tool_schemas.json"))?;
+            println!("{}", serde_json::to_string_pretty(&schemas)?);
         }
     }
 

--- a/goose-runtime/goose_runtime/__init__.py
+++ b/goose-runtime/goose_runtime/__init__.py
@@ -1,4 +1,5 @@
-"""Goose runtime package exposing task graph utilities."""
+"""Goose runtime package exposing task graph utilities and tool registry."""
 from .task_graph import Task, TaskGraph
+from .tools import ToolRegistry
 
-__all__ = ["Task", "TaskGraph"]
+__all__ = ["Task", "TaskGraph", "ToolRegistry"]

--- a/goose-runtime/goose_runtime/tools.py
+++ b/goose-runtime/goose_runtime/tools.py
@@ -1,0 +1,23 @@
+"""Registry exposing MCP tool schemas to Goose runtime."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mcp_tools.schemas import TOOL_SCHEMAS
+
+
+class ToolRegistry:
+    """Simple in-memory registry backed by shared tool schemas."""
+
+    _schemas: Dict[str, Dict[str, Any]] = TOOL_SCHEMAS
+
+    @classmethod
+    def get_schema(cls, name: str) -> Dict[str, Any]:
+        return cls._schemas.get(name, {})
+
+    @classmethod
+    def list(cls) -> Dict[str, Dict[str, Any]]:
+        return cls._schemas
+
+
+__all__ = ["ToolRegistry"]

--- a/goose-runtime/tests/test_tool_registry.py
+++ b/goose-runtime/tests/test_tool_registry.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from goose_runtime import ToolRegistry
+
+
+def test_list_contains_repo_schema():
+    schemas = ToolRegistry.list()
+    assert "repo" in schemas
+    assert schemas["repo"]["required"] == ["action"]

--- a/mcp-tools/mcp_tools/__init__.py
+++ b/mcp-tools/mcp_tools/__init__.py
@@ -1,4 +1,19 @@
-"""MCP tool invocation helpers."""
+"""MCP tool invocation helpers and adapters."""
 from .tool import call_tool
+from .hub import LocalHub
+from .adapters import repo, lint, test, build, docs, pr, deploy, eval
+from .schemas import TOOL_SCHEMAS
 
-__all__ = ["call_tool"]
+__all__ = [
+    "call_tool",
+    "LocalHub",
+    "repo",
+    "lint",
+    "test",
+    "build",
+    "docs",
+    "pr",
+    "deploy",
+    "eval",
+    "TOOL_SCHEMAS",
+]

--- a/mcp-tools/mcp_tools/adapters.py
+++ b/mcp-tools/mcp_tools/adapters.py
@@ -1,0 +1,43 @@
+"""High level adapters wrapping tool invocations via the LocalHub."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .hub import LocalHub
+
+_hub = LocalHub()
+
+
+def repo(action: str, path: str, message: str = "") -> Dict[str, Any]:
+    return _hub.call("repo", {"action": action, "path": path, "message": message})
+
+
+def lint(targets: List[str]) -> Dict[str, Any]:
+    return _hub.call("lint", {"targets": targets})
+
+
+def test(path: str = ".") -> Dict[str, Any]:
+    return _hub.call("test", {"path": path})
+
+
+def build(path: str = ".") -> Dict[str, Any]:
+    return _hub.call("build", {"path": path})
+
+
+def docs(path: str = ".") -> Dict[str, Any]:
+    return _hub.call("docs", {"path": path})
+
+
+def pr(title: str, body: str = "") -> Dict[str, Any]:
+    return _hub.call("pr", {"title": title, "body": body})
+
+
+def deploy(env: str) -> Dict[str, Any]:
+    return _hub.call("deploy", {"env": env})
+
+
+def eval(suite: str) -> Dict[str, Any]:
+    return _hub.call("eval", {"suite": suite})
+
+
+__all__ = ["repo", "lint", "test", "build", "docs", "pr", "deploy", "eval"]

--- a/mcp-tools/mcp_tools/hub.py
+++ b/mcp-tools/mcp_tools/hub.py
@@ -1,0 +1,46 @@
+"""Simple local hub to spawn tool servers and forward remote calls."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .tool import call_tool
+
+
+class LocalHub:
+    """Manage tool servers locally or forward to a remote Boaster instance."""
+
+    def __init__(self, boaster_url: Optional[str] = None) -> None:
+        self.boaster_url = boaster_url
+        self._procs: Dict[str, subprocess.Popen] = {}
+
+    def spawn(self, name: str, cmd: List[str]) -> None:
+        """Spawn a tool server if not already running."""
+        proc = self._procs.get(name)
+        if proc and proc.poll() is None:
+            return
+        self._procs[name] = subprocess.Popen(cmd)
+
+    def call(self, tool: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke a tool locally or remotely."""
+        if self.boaster_url:
+            response = requests.post(
+                f"{self.boaster_url}/tools/{tool}", json=payload, timeout=30
+            )
+            response.raise_for_status()
+            return response.json()
+        return call_tool(tool, payload)
+
+    def shutdown(self) -> None:
+        """Terminate all spawned processes."""
+        for proc in self._procs.values():
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+        self._procs.clear()
+
+
+__all__ = ["LocalHub"]

--- a/mcp-tools/mcp_tools/schemas.py
+++ b/mcp-tools/mcp_tools/schemas.py
@@ -1,0 +1,14 @@
+"""Load JSON schemas describing available MCP tools."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+# shared/tool_schemas.json sits two directories above this file
+_SCHEMAS_PATH = Path(__file__).resolve().parents[2] / "shared" / "tool_schemas.json"
+
+with _SCHEMAS_PATH.open("r", encoding="utf-8") as fh:
+    TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = json.load(fh)
+
+__all__ = ["TOOL_SCHEMAS"]

--- a/mcp-tools/tests/test_adapters.py
+++ b/mcp-tools/tests/test_adapters.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcp_tools import repo, TOOL_SCHEMAS
+
+
+def test_repo_adapter_roundtrip():
+    result = repo("status", ".")
+    assert result["tool"] == "repo"
+    assert "repo" in TOOL_SCHEMAS

--- a/shared/tool_schemas.json
+++ b/shared/tool_schemas.json
@@ -1,0 +1,69 @@
+{
+  "repo": {
+    "type": "object",
+    "properties": {
+      "action": {"type": "string"},
+      "path": {"type": "string"},
+      "message": {"type": "string"}
+    },
+    "required": ["action"],
+    "additionalProperties": false
+  },
+  "lint": {
+    "type": "object",
+    "properties": {
+      "targets": {"type": "array", "items": {"type": "string"}}
+    },
+    "required": ["targets"],
+    "additionalProperties": false
+  },
+  "test": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"}
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "build": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"}
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "docs": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"}
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "pr": {
+    "type": "object",
+    "properties": {
+      "title": {"type": "string"},
+      "body": {"type": "string"}
+    },
+    "required": ["title"],
+    "additionalProperties": false
+  },
+  "deploy": {
+    "type": "object",
+    "properties": {
+      "env": {"type": "string"}
+    },
+    "required": ["env"],
+    "additionalProperties": false
+  },
+  "eval": {
+    "type": "object",
+    "properties": {
+      "suite": {"type": "string"}
+    },
+    "required": ["suite"],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## Summary
- add LocalHub for spawning tool servers or proxying to remote Boaster
- implement adapters for repo, lint, test, build, docs, PR, deploy and eval tools
- define shared JSON schemas and expose through Goose runtime and CLI

## Testing
- `pytest mcp-tools/tests goose-runtime/tests -q`
- `cd codex-cli && cargo test`

