### PR TITLE
chore: add eslint config for vscodiam package

### DIFF
--- a/vscodiam/eslint.config.mjs
+++ b/vscodiam/eslint.config.mjs
@@ -1,0 +1,15 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs['flat/recommended'],
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add flat ESLint config so `vscodiam` lints its TypeScript sources

## Testing
- `npx turbo run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `cd vscodiam && pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff8c0b92c8332a78cfa365a33ed6a