### PR TITLE
feat: add ticket flow and evaluation harness

### DIFF
--- a/docs/cli_flow.md
+++ b/docs/cli_flow.md
@@ -1,0 +1,27 @@
+# CLI Flow: `codex init` and `codex run`
+
+This example demonstrates how to initialise a project and execute a sample plan using the `codex-cli` tool. The plan streams execution to a Goose runtime and can invoke MCP tools defined in `shared/tool_schemas.json`.
+
+## Initialise a project
+
+```bash
+codex init demo-project
+```
+
+This registers the project with the Codex Boaster backend and creates initial configuration files.
+
+## Execute a plan
+
+1. Save the sample plan:
+
+   ```bash
+   cp examples/sample_plan.json plan.json
+   ```
+
+2. Run the plan and stream output through Goose:
+
+   ```bash
+   codex run demo-project --ws-url ws://localhost:9001/run < plan.json
+   ```
+
+The CLI posts the plan to the backend, which coordinates Goose and available MCP tools to perform each task. Output from Goose is printed to the console.

--- a/examples/sample_plan.json
+++ b/examples/sample_plan.json
@@ -1,0 +1,11 @@
+{
+  "tasks": [
+    {
+      "id": "t1",
+      "action": "echo",
+      "args": {
+        "message": "hello from codex plan"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "evaluate": "./scripts/evaluate.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/evaluate.sh
+++ b/scripts/evaluate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run unit tests with coverage threshold
+npm test -- --coverage --coverageThreshold='{"global":{"branches":80,"functions":80,"lines":80,"statements":80}}'
+
+# Lint the VS Code extension with no warnings allowed
+npm --workspace vscodiam run lint -- --max-warnings=0
+
+# Basic secrets scan using ripgrep for known secret patterns
+# Ignores documentation and tests to minimise false positives
+if rg -n '(sk_live|AKIA|AIzaSy)' --glob '!*.example*' --glob '!docs/**' --glob '!**/test*' --glob '!scripts/evaluate.sh' >/tmp/secret_scan.log; then
+  echo "Potential secrets detected:" >&2
+  cat /tmp/secret_scan.log >&2
+  exit 1
+fi
+
+echo "Evaluation checks passed"

--- a/vscodiam/package.json
+++ b/vscodiam/package.json
@@ -9,10 +9,14 @@
   "browser": "./dist/extension-web.js",
   "extensionKind": ["ui", "web"],
 
-  "activationEvents": ["onCommand:boaster.prepareRelease"],
+  "activationEvents": [
+    "onCommand:boaster.prepareRelease",
+    "onCommand:boaster.ticketToPlan"
+  ],
   "contributes": {
     "commands": [
-      { "command": "boaster.prepareRelease", "title": "Boaster: Prepare Release" }
+      { "command": "boaster.prepareRelease", "title": "Boaster: Prepare Release" },
+      { "command": "boaster.ticketToPlan", "title": "Boaster: Ticket To Plan" }
     ]
   },
 

--- a/vscodiam/src/extension.ts
+++ b/vscodiam/src/extension.ts
@@ -3,7 +3,8 @@ import * as vscode from 'vscode';
 const isWeb = typeof navigator !== 'undefined';
 
 export function activate(ctx: vscode.ExtensionContext) {
-  const cmd = vscode.commands.registerCommand('boaster.prepareRelease', async () => {
+  // Existing release signing flow
+  const releaseCmd = vscode.commands.registerCommand('boaster.prepareRelease', async () => {
     await vscode.window.showInformationMessage('Preparing release...');
     if (isWeb) {
       // Call backend via HTTP/MCP when running in web.
@@ -25,7 +26,42 @@ export function activate(ctx: vscode.ExtensionContext) {
       vscode.window.showWarningMessage('Release aborted');
     }
   });
-  ctx.subscriptions.push(cmd);
+  ctx.subscriptions.push(releaseCmd);
+
+  // Ticket-to-plan demonstration flow
+  const ticketCmd = vscode.commands.registerCommand('boaster.ticketToPlan', async () => {
+    const issue = await vscode.window.showQuickPick(
+      ['Sample issue: Improve docs', 'Sample issue: Fix bug'],
+      { placeHolder: 'Select an issue to plan' }
+    );
+    if (!issue) {
+      return;
+    }
+
+    const approval = await vscode.window.showQuickPick(
+      ['Approve task graph', 'Reject'],
+      { placeHolder: `Approve generated plan for "${issue}"?` }
+    );
+    if (approval !== 'Approve task graph') {
+      vscode.window.showInformationMessage('Plan rejected');
+      return;
+    }
+
+    const ws = vscode.workspace.workspaceFolders?.[0];
+    if (!ws) {
+      vscode.window.showWarningMessage('No workspace open to apply diff');
+      return;
+    }
+
+    const patchUri = vscode.Uri.joinPath(ws.uri, 'TICKET_PATCH.txt');
+    const encoder = new TextEncoder();
+    await vscode.workspace.fs.writeFile(
+      patchUri,
+      encoder.encode('Placeholder diff applied\n')
+    );
+    vscode.window.showInformationMessage(`Diff applied to ${patchUri.fsPath}`);
+  });
+  ctx.subscriptions.push(ticketCmd);
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary
- add ticket-to-plan demo command to VS Code extension
- document CLI init/run workflow and include sample plan
- add evaluation script enforcing tests, lint and secret scanning

## Testing
- `./scripts/evaluate.sh`